### PR TITLE
[Housekeeping] Bump Android Target to 35

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -9,11 +9,11 @@ plugins {
 
 android {
     namespace = "com.hello.curiosity.regeneration.android"
-    compileSdk = 34
+    compileSdk = 35
     defaultConfig {
         applicationId = "com.hello.curiosity.regeneration.android"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.0"
+agp = "8.5.1"
 androidx-activityCompose = "1.9.0"
 compose = "1.6.7"
 compose-compiler = "1.5.4"


### PR DESCRIPTION
## Description

This bumps the Android target version to **35** and the AGP version to **8.5.1**, removing the lining warning.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [ ] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
